### PR TITLE
Prepare to handle syncing added ExternalName service rules

### DIFF
--- a/api/types/annotation.go
+++ b/api/types/annotation.go
@@ -1,9 +1,50 @@
 package types
 
+import (
+	"regexp"
+
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+)
+
 type Annotation struct {
 	Key     string `json:"key"`
 	Value   string `json:"value"`
 	IsRegex bool   `json:"isRegex"`
 }
 
+func (annotation *Annotation) AnnotatesNamespace(namespace *v1.Namespace) bool {
+	for key, value := range namespace.Annotations {
+		if key == annotation.Key {
+			if annotation.IsRegex {
+				isMatch, err := regexp.MatchString(annotation.Value, value)
+				if err != nil {
+					log.Errorf("failed to compile pattern: %s", err.Error())
+				}
+				if isMatch {
+					return true
+				}
+			} else if value == annotation.Value {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 type Annotations []Annotation
+
+func (annotations Annotations) AnnotatesNamespace(namespace *v1.Namespace) bool {
+	for _, annotation := range annotations {
+		if annotation.AnnotatesNamespace(namespace) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (annotations Annotations) IsEmpty() bool {
+	return len(annotations) == 0
+}

--- a/api/types/v1/externalsyncrule.go
+++ b/api/types/v1/externalsyncrule.go
@@ -1,8 +1,12 @@
 package v1
 
 import (
+	"context"
+
 	"github.com/alehechka/kube-external-sync/api/types"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // +kubebuilder:object:root=true
@@ -87,4 +91,54 @@ func (rule *ExternalSyncRule) HasService() bool {
 func (rule *ExternalSyncRule) HasIngress() bool {
 	return rule.Spec.Ingress != nil &&
 		len(rule.Spec.Ingress.Name) > 0
+}
+
+// ShouldSyncNamespace determines whether or not the given Namespace should be synced
+func (rule *ExternalSyncRule) ShouldSyncNamespace(namespace *v1.Namespace) bool {
+	rules := rule.Spec.Rules
+
+	if rule.Spec.Namespace == namespace.Name {
+		return false
+	}
+
+	if rules.Namespaces.Exclude.IsExcluded(namespace.Name) || rules.Namespaces.ExcludeRegex.IsRegexExcluded(namespace.Name) {
+		return false
+	}
+
+	if rules.Namespaces.Include.IsEmpty() && rules.Namespaces.IncludeRegex.IsEmpty() && rules.Namespaces.IncludeAnnotation.IsEmpty() {
+		return true
+	}
+
+	if rules.Namespaces.Include.IsIncluded(namespace.Name) || rules.Namespaces.IncludeRegex.IsRegexIncluded(namespace.Name) || rules.Namespaces.IncludeAnnotation.AnnotatesNamespace(namespace) {
+		return true
+	}
+
+	return false
+}
+
+// Namespaces returns a list of all namespaces that the given Rule allows for syncing
+func (rule *ExternalSyncRule) Namespaces(ctx context.Context, clientset kubernetes.Interface) (namespaces []v1.Namespace) {
+	list, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+
+	for _, namespace := range list.Items {
+		if rule.ShouldSyncNamespace(&namespace) {
+			namespaces = append(namespaces, namespace)
+		}
+	}
+
+	return
+}
+
+// ShouldSyncNamespace iterates over the list to determine whether or not the given Namespace should be synced
+func (list *ExternalSyncRuleList) ShouldSyncNamespace(namespace *v1.Namespace) bool {
+	for _, rule := range list.Items {
+		if rule.ShouldSyncNamespace(namespace) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/api/types/v1/externalsyncrule.go
+++ b/api/types/v1/externalsyncrule.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alehechka/kube-external-sync/api/types"
 	v1 "k8s.io/api/core/v1"
@@ -141,4 +142,12 @@ func (list *ExternalSyncRuleList) ShouldSyncNamespace(namespace *v1.Namespace) b
 	}
 
 	return false
+}
+
+func (rule *ExternalSyncRule) ServiceExternalName() string {
+	if rule == nil || !rule.HasService() {
+		return ""
+	}
+
+	return fmt.Sprintf("%s.%s.%s", rule.Spec.Service.Name, rule.Spec.Namespace, rule.Spec.Service.ExternalNameSuffix)
 }

--- a/api/types/v1/externalsyncrule.go
+++ b/api/types/v1/externalsyncrule.go
@@ -29,9 +29,10 @@ type ExternalSyncRuleList struct {
 
 // ExternalSyncRuleSpec is the spec attribute of the ExternalSyncRule CRD
 type ExternalSyncRuleSpec struct {
-	Service *Service `json:"service,omitempty"`
-	Ingress *Ingress `json:"ingress,omitempty"`
-	Rules   Rules    `json:"rules"`
+	Namespace string   `json:"namespace"`
+	Service   *Service `json:"service,omitempty"`
+	Ingress   *Ingress `json:"ingress,omitempty"`
+	Rules     Rules    `json:"rules"`
 }
 
 // +kubebuilder:object:generate=true
@@ -39,9 +40,16 @@ type ExternalSyncRuleSpec struct {
 // Service defines the attributes of the Service to sync
 type Service struct {
 	Name               string `json:"name"`
-	Namespace          string `json:"namespace"`
 	Kind               string `json:"kind"`
 	ExternalNameSuffix string `json:"externalNameSuffix"`
+}
+
+func (service *Service) IsService() bool {
+	return service.Kind == "Service"
+}
+
+func (service *Service) IsTraefikService() bool {
+	return service.Kind == "Traefik Service"
 }
 
 // +kubebuilder:object:generate=true
@@ -49,7 +57,6 @@ type Service struct {
 // Ingress defines the attributes of the Ingress to sync
 type Ingress struct {
 	Name           string `json:"name"`
-	Namespace      string `json:"namespace"`
 	Kind           string `json:"kind"`
 	TopLevelDomain string `json:"topLevelDomain"`
 }
@@ -74,12 +81,10 @@ type NamespaceRules struct {
 
 func (rule *ExternalSyncRule) HasService() bool {
 	return rule.Spec.Service != nil &&
-		len(rule.Spec.Service.Name) > 0 &&
-		len(rule.Spec.Service.Namespace) > 0
+		len(rule.Spec.Service.Name) > 0
 }
 
 func (rule *ExternalSyncRule) HasIngress() bool {
 	return rule.Spec.Ingress != nil &&
-		len(rule.Spec.Ingress.Name) > 0 &&
-		len(rule.Spec.Ingress.Namespace) > 0
+		len(rule.Spec.Ingress.Name) > 0
 }

--- a/api/types/v1/externalsyncrule.go
+++ b/api/types/v1/externalsyncrule.go
@@ -38,9 +38,10 @@ type ExternalSyncRuleSpec struct {
 
 // Service defines the attributes of the Service to sync
 type Service struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-	Kind      string `json:"kind"`
+	Name               string `json:"name"`
+	Namespace          string `json:"namespace"`
+	Kind               string `json:"kind"`
+	ExternalNameSuffix string `json:"externalNameSuffix"`
 }
 
 // +kubebuilder:object:generate=true

--- a/client/externalsyncrules.go
+++ b/client/externalsyncrules.go
@@ -29,12 +29,9 @@ func (client *Client) ExternalSyncRuleEventHandler(event watch.Event) error {
 func (client *Client) AddedExternalSyncRuleHandler(rule *typesv1.ExternalSyncRule) (err error) {
 	ruleLogger(rule).Infof("added")
 
-	var service *v1.Service
+	var service *v1.Service = nil
 	if rule.HasService() && rule.Spec.Service.IsService() {
-		service, err = client.GetService(rule.Spec.Namespace, rule.Spec.Service.Name)
-		if err != nil {
-			return err
-		}
+		service, _ = client.GetService(rule.Spec.Namespace, rule.Spec.Service.Name)
 	}
 
 	for _, namespace := range rule.Namespaces(client.Context, client.DefaultClientset) {

--- a/client/externalsyncrules.go
+++ b/client/externalsyncrules.go
@@ -3,6 +3,7 @@ package client
 import (
 	typesv1 "github.com/alehechka/kube-external-sync/api/types/v1"
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -15,11 +16,31 @@ func (client *Client) ExternalSyncRuleEventHandler(event watch.Event) error {
 
 	switch event.Type {
 	case watch.Added:
-		ruleLogger(rule).Infof("added, HasService: %v, HasIngress: %v, IncludeAnnotations: %#v", rule.HasService(), rule.HasIngress(), rule.Spec.Rules.Namespaces.IncludeAnnotation)
+		return client.AddedExternalSyncRuleHandler(rule)
 	case watch.Modified:
 		ruleLogger(rule).Infof("modified: %#v", rule)
 	case watch.Deleted:
 		ruleLogger(rule).Infof("deleted: %#v", rule)
+	}
+
+	return nil
+}
+
+func (client *Client) AddedExternalSyncRuleHandler(rule *typesv1.ExternalSyncRule) (err error) {
+	ruleLogger(rule).Infof("added")
+
+	var service *v1.Service
+	if rule.HasService() && rule.Spec.Service.IsService() {
+		service, err = client.GetService(rule.Spec.Namespace, rule.Spec.Service.Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, namespace := range rule.Namespaces(client.Context, client.DefaultClientset) {
+		if service != nil {
+			client.CreateUpdateExternalNameService(rule, &namespace, service)
+		}
 	}
 
 	return nil

--- a/client/loggers.go
+++ b/client/loggers.go
@@ -3,8 +3,17 @@ package client
 import (
 	typesv1 "github.com/alehechka/kube-external-sync/api/types/v1"
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 )
 
 func ruleLogger(rule *typesv1.ExternalSyncRule) *log.Entry {
 	return log.WithFields(log.Fields{"name": rule.Name, "kind": "ExternalSyncRule"})
+}
+
+func serviceLogger(service *v1.Service) *log.Entry {
+	return log.WithFields(log.Fields{"name": service.Name, "kind": "Service", "namespace": service.Namespace})
+}
+
+func namespaceLogger(namespace *v1.Namespace) *log.Entry {
+	return log.WithFields(log.Fields{"name": namespace.Name, "kind": "Namespace"})
 }

--- a/client/namespaces.go
+++ b/client/namespaces.go
@@ -1,0 +1,15 @@
+package client
+
+import (
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (client *Client) ListNamespaces() (namespaces *v1.NamespaceList, err error) {
+	namespaces, err = client.DefaultClientset.CoreV1().Namespaces().List(client.Context, metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("failed to list namespaces: %s", err.Error())
+	}
+	return
+}

--- a/client/services.go
+++ b/client/services.go
@@ -1,9 +1,15 @@
 package client
 
 import (
+	typesv1 "github.com/alehechka/kube-external-sync/api/types/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func (client *Client) CreateUpdateExternalNameService(rule *typesv1.ExternalSyncRule, namespace *v1.Namespace, service *v1.Service) error {
+	serviceLogger(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: namespace.Name}}).Infof("creating")
+	return nil
+}
 
 func (client *Client) GetService(namespace, name string) (service *v1.Service, err error) {
 	service, err = client.DefaultClientset.CoreV1().Services(namespace).Get(client.Context, name, metav1.GetOptions{})

--- a/client/services.go
+++ b/client/services.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (client *Client) GetService(namespace, name string) (service *v1.Service, err error) {
+	service, err = client.DefaultClientset.CoreV1().Services(namespace).Get(client.Context, name, metav1.GetOptions{})
+	if err != nil {
+		serviceLogger(&v1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}).
+			Errorf("failed to get service: %s", err.Error())
+	}
+	return
+}
+
+func (client *Client) ListServices(namespace string) (list *v1.ServiceList, err error) {
+	list, err = client.DefaultClientset.CoreV1().Services(namespace).List(client.Context, metav1.ListOptions{})
+	if err != nil {
+		namespaceLogger(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}).
+			Errorf("failed to list services: %s", err.Error())
+	}
+	return
+}

--- a/constants/annotations.go
+++ b/constants/annotations.go
@@ -1,0 +1,10 @@
+package constants
+
+// ManagedByAnnotationKey is an annotation key appended to kube-external-sync managed resources.
+const ManagedByAnnotationKey = "app.kubernetes.io/managed-by"
+
+// ManagedByAnnotationValue is an annotation value appended to kube-external-sync managed resources.
+const ManagedByAnnotationValue = "kube-external-sync"
+
+// LastAppliedConfigurationAnnotationKey is an annotation created by Kubernetes to keep track of last config
+const LastAppliedConfigurationAnnotationKey = "kubectl.kubernetes.io/last-applied-configuration"

--- a/deploy/helm/kube-external-sync/templates/crds/externalsyncrule.yaml
+++ b/deploy/helm/kube-external-sync/templates/crds/externalsyncrule.yaml
@@ -15,7 +15,11 @@ spec:
           properties:
             spec:
               type: object
+              required: 
+                - namespace
               properties:
+                namespace:
+                  type: string
                 service:
                   type: object
                   properties:
@@ -27,8 +31,6 @@ spec:
                       enum: 
                         - Service
                         # - Traefik Service
-                    namespace:
-                      type: string
                     externalNameSuffix:
                       type: string
                       default: 'svc.cluster.local'
@@ -37,7 +39,6 @@ spec:
                         - 'traefik.mesh'
                   required:
                     - name
-                    - namespace
                 ingress:
                   type: object
                   properties:
@@ -51,13 +52,10 @@ spec:
                         # - Ingress Route
                         # - Ingress Route TCP
                         # - Ingress Route UDP
-                    namespace:
-                      type: string
                     topLevelDomain:
                       type: string
                   required:
                     - name
-                    - namespace
                 rules:
                   type: object
                   properties:

--- a/deploy/helm/kube-external-sync/templates/crds/externalsyncrule.yaml
+++ b/deploy/helm/kube-external-sync/templates/crds/externalsyncrule.yaml
@@ -26,9 +26,15 @@ spec:
                       default: Service
                       enum: 
                         - Service
-                        - Traefik Service
+                        # - Traefik Service
                     namespace:
                       type: string
+                    externalNameSuffix:
+                      type: string
+                      default: 'svc.cluster.local'
+                      enum:
+                        - 'svc.cluster.local'
+                        - 'traefik.mesh'
                   required:
                     - name
                     - namespace
@@ -42,9 +48,9 @@ spec:
                       default: Ingress
                       enum: 
                         - Ingress
-                        - Ingress Route
-                        - Ingress Route TCP
-                        - Ingress Route UDP
+                        # - Ingress Route
+                        # - Ingress Route TCP
+                        # - Ingress Route UDP
                     namespace:
                       type: string
                     topLevelDomain:

--- a/deploy/kubectl/annotated-namespace.yaml
+++ b/deploy/kubectl/annotated-namespace.yaml
@@ -1,0 +1,6 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: annotated
+  annotations:
+    alehechka/feature-branch: feature/annotated

--- a/deploy/kubectl/external-rule.yaml
+++ b/deploy/kubectl/external-rule.yaml
@@ -3,9 +3,9 @@ kind: ExternalSyncRule
 metadata:
   name: external-rule
 spec:
+  namespace: default
   service:
     name: nginx
-    namespace: default
   rules:
     namespaces:
       includeAnnotation:


### PR DESCRIPTION
This PR doesn't yet sync any resources, but does setup a lot of the code and validators to prepare for syncing an `Added` `ExternalSyncRule` with a Service defined in the spec.

Additionally, I made some small tweaks to the CRD to better reflect intended usage.