### PR TITLE
Sync Ingresses

### DIFF
--- a/api/types/v1/clientset/register.go
+++ b/api/types/v1/clientset/register.go
@@ -9,6 +9,7 @@ import (
 
 const GroupName = "kube-external-sync.io"
 const GroupVersion = "v1"
+const ExternalSyncRule = "ExternalSyncRule"
 
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
 

--- a/api/types/v1/externalsyncrule.go
+++ b/api/types/v1/externalsyncrule.go
@@ -149,6 +149,12 @@ func (rule *ExternalSyncRule) ShouldSyncService(service *v1.Service) bool {
 		rule.Spec.Service.Name == service.Name
 }
 
+func (rule *ExternalSyncRule) ShouldSyncIngress(ingress *networkingv1.Ingress) bool {
+	return rule.HasIngress() &&
+		rule.Spec.Namespace == ingress.Namespace &&
+		rule.Spec.Service.Name == ingress.Name
+}
+
 // ShouldSyncNamespace determines whether or not the given Namespace should be synced
 func (rule *ExternalSyncRule) ShouldSyncNamespace(namespace *v1.Namespace) bool {
 	rules := rule.Spec.Rules

--- a/api/types/v1/externalsyncrule.go
+++ b/api/types/v1/externalsyncrule.go
@@ -105,10 +105,6 @@ func (ingress *Ingress) PrepareIngressRules(namespace *v1.Namespace, netIngress 
 }
 
 func PrepareTLD(namespace *v1.Namespace, tld string) string {
-	if len(tld) == 0 {
-		return ""
-	}
-
 	subdomains := strings.Split(tld, ".")
 	subdomains[0] = namespace.Name
 

--- a/client/annotations.go
+++ b/client/annotations.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"reflect"
+
+	"github.com/alehechka/kube-external-sync/constants"
+)
+
+func AnnotationsAreEqual(a, b map[string]string) bool {
+	aCopy := CopyAnnotations(a)
+	bCopy := CopyAnnotations(b)
+
+	return reflect.DeepEqual(aCopy, bCopy)
+}
+
+func CopyAnnotations(m map[string]string) map[string]string {
+	copy := make(map[string]string)
+
+	for key, value := range m {
+		if key == constants.ManagedByAnnotationKey || key == constants.LastAppliedConfigurationAnnotationKey {
+			continue
+		}
+		copy[key] = value
+	}
+
+	return copy
+}

--- a/client/annotations.go
+++ b/client/annotations.go
@@ -3,7 +3,11 @@ package client
 import (
 	"reflect"
 
+	typesv1 "github.com/alehechka/kube-external-sync/api/types/v1"
+	"github.com/alehechka/kube-external-sync/api/types/v1/clientset"
 	"github.com/alehechka/kube-external-sync/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 func AnnotationsAreEqual(a, b map[string]string) bool {
@@ -32,4 +36,13 @@ func Manage(m map[string]string) map[string]string {
 	}
 	m[constants.ManagedByAnnotationKey] = constants.ManagedByAnnotationValue
 	return m
+}
+
+func OwnerReference(rule *typesv1.ExternalSyncRule) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: clientset.GroupName,
+		Kind:       clientset.ExternalSyncRule,
+		Name:       rule.Name,
+		UID:        uuid.NewUUID(),
+	}
 }

--- a/client/annotations.go
+++ b/client/annotations.go
@@ -25,3 +25,11 @@ func CopyAnnotations(m map[string]string) map[string]string {
 
 	return copy
 }
+
+func Manage(m map[string]string) map[string]string {
+	if m == nil {
+		m = make(map[string]string)
+	}
+	m[constants.ManagedByAnnotationKey] = constants.ManagedByAnnotationValue
+	return m
+}

--- a/client/client.go
+++ b/client/client.go
@@ -25,6 +25,7 @@ type Client struct {
 	ExternalSyncRuleWatcher watch.Interface
 	NamespaceWatcher        watch.Interface
 	ServiceWatcher          watch.Interface
+	IngressWatcher          watch.Interface
 	SignalChannel           chan os.Signal
 }
 

--- a/client/ingresses.go
+++ b/client/ingresses.go
@@ -1,9 +1,12 @@
 package client
 
 import (
+	typesv1 "github.com/alehechka/kube-external-sync/api/types/v1"
 	"github.com/alehechka/kube-external-sync/constants"
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -31,6 +34,74 @@ func (client *Client) IngressEventHandler(event watch.Event) error {
 	}
 
 	return nil
+}
+
+func (client *Client) GetIngress(namespace, name string) (ingress *networkingv1.Ingress, err error) {
+	ingress, err = client.DefaultClientset.NetworkingV1().Ingresses(namespace).Get(client.Context, name, metav1.GetOptions{})
+	if err != nil {
+		ingressNameLogger(namespace, name).
+			Errorf("failed to get ingress: %s", err.Error())
+	}
+	return
+}
+
+func (client *Client) ListIngresses(namespace string) (list *networkingv1.IngressList, err error) {
+	list, err = client.DefaultClientset.NetworkingV1().Ingresses(namespace).List(client.Context, metav1.ListOptions{})
+	if err != nil {
+		namespaceNameLogger(namespace).
+			Errorf("failed to list ingresses: %s", err.Error())
+	}
+	return
+}
+
+func (client *Client) CreateIngress(rule *typesv1.ExternalSyncRule, namespace *v1.Namespace, ingress *networkingv1.Ingress) error {
+	newIngress := PrepareIngress(rule, namespace, ingress)
+
+	logger := ingressLogger(newIngress)
+	logger.Infof("creating")
+
+	_, err := client.DefaultClientset.NetworkingV1().Ingresses(namespace.Name).Create(client.Context, newIngress, metav1.CreateOptions{})
+
+	if err != nil {
+		logger.Errorf("failed to create ingress - %s", err.Error())
+	}
+
+	return err
+}
+
+func (client *Client) UpdateIngress(rule *typesv1.ExternalSyncRule, namespace *v1.Namespace, ingress *networkingv1.Ingress) error {
+	updateIngress := PrepareIngress(rule, namespace, ingress)
+
+	logger := ingressLogger(updateIngress)
+	logger.Infof("updating")
+
+	_, err := client.DefaultClientset.NetworkingV1().Ingresses(namespace.Name).Update(client.Context, updateIngress, metav1.UpdateOptions{})
+
+	if err != nil {
+		logger.Errorf("failed to update service - %s", err.Error())
+	}
+
+	return err
+}
+
+func (client *Client) DeleteIngress(namespace *v1.Namespace, ingress *networkingv1.Ingress) (err error) {
+	logger := ingressLogger(ingress, namespace)
+
+	logger.Infof("deleting")
+
+	err = client.DefaultClientset.NetworkingV1().Ingresses(namespace.Name).Delete(client.Context, ingress.Name, metav1.DeleteOptions{})
+	if err != nil {
+		logger.Errorf("failed to delete ingress - %s", err.Error())
+	}
+
+	return
+}
+
+func PrepareIngress(rule *typesv1.ExternalSyncRule, namespace *v1.Namespace, service *networkingv1.Ingress) *networkingv1.Ingress {
+	annotations := CopyAnnotations(service.Annotations)
+	annotations[constants.ManagedByAnnotationKey] = constants.ManagedByAnnotationValue
+
+	return &networkingv1.Ingress{}
 }
 
 func IsIngressManagedBy(ingress *networkingv1.Ingress) bool {

--- a/client/ingresses.go
+++ b/client/ingresses.go
@@ -98,10 +98,18 @@ func (client *Client) DeleteIngress(namespace *v1.Namespace, ingress *networking
 }
 
 func PrepareIngress(rule *typesv1.ExternalSyncRule, namespace *v1.Namespace, service *networkingv1.Ingress) *networkingv1.Ingress {
-	annotations := CopyAnnotations(service.Annotations)
-	annotations[constants.ManagedByAnnotationKey] = constants.ManagedByAnnotationValue
+	annotations := Manage(CopyAnnotations(service.Annotations))
 
-	return &networkingv1.Ingress{}
+	return &networkingv1.Ingress{
+		TypeMeta: service.TypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        service.Name,
+			Namespace:   namespace.Name,
+			Labels:      service.Labels,
+			Annotations: annotations,
+		},
+		Spec: networkingv1.IngressSpec{},
+	}
 }
 
 func IsIngressManagedBy(ingress *networkingv1.Ingress) bool {

--- a/client/ingresses.go
+++ b/client/ingresses.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"github.com/alehechka/kube-external-sync/constants"
+	log "github.com/sirupsen/logrus"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func (client *Client) IngressEventHandler(event watch.Event) error {
+	ingress, ok := event.Object.(*networkingv1.Ingress)
+	if !ok {
+		log.Error("failed to cast Ingress")
+		return nil
+	}
+
+	if IsIngressManagedBy(ingress) {
+		return nil
+	}
+
+	switch event.Type {
+	case watch.Added:
+		ingressLogger(ingress).Infof("added")
+		// return client.AddedIngressHandler(ingress)
+	case watch.Modified:
+		ingressLogger(ingress).Infof("modified")
+		// return client.ModifiedIngressHandler(ingress)
+	case watch.Deleted:
+		ingressLogger(ingress).Infof("deleted")
+		// return client.DeletedIngressHandler(ingress)
+	}
+
+	return nil
+}
+
+func IsIngressManagedBy(ingress *networkingv1.Ingress) bool {
+	managedBy, ok := ingress.Annotations[constants.ManagedByAnnotationKey]
+
+	return ok && managedBy == constants.ManagedByAnnotationValue
+}

--- a/client/loggers.go
+++ b/client/loggers.go
@@ -4,6 +4,7 @@ import (
 	typesv1 "github.com/alehechka/kube-external-sync/api/types/v1"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 func ruleLogger(rule *typesv1.ExternalSyncRule) *log.Entry {
@@ -33,4 +34,17 @@ func namespaceLogger(namespace *v1.Namespace) *log.Entry {
 
 func namespaceNameLogger(name string) *log.Entry {
 	return log.WithFields(log.Fields{"name": name, "kind": "Namespace"})
+}
+
+func ingressLogger(service *networkingv1.Ingress, namespaces ...*v1.Namespace) *log.Entry {
+	namespace := service.Namespace
+	if len(namespaces) > 0 {
+		namespace = namespaces[0].Name
+	}
+
+	return ingressNameLogger(namespace, service.Name)
+}
+
+func ingressNameLogger(namespace, name string) *log.Entry {
+	return log.WithFields(log.Fields{"name": name, "kind": "Ingress", "namespace": namespace})
 }

--- a/client/namespaces.go
+++ b/client/namespaces.go
@@ -59,6 +59,12 @@ func (client *Client) SyncResourcesToNamespace(namespace *v1.Namespace, rule *ty
 		}
 	}
 
+	if rule.HasIngress() && rule.Spec.Ingress.IsIngress() {
+		if ingress, err := client.GetIngress(rule.Spec.Namespace, rule.Spec.Ingress.Name); ingress != nil && err == nil {
+			client.CreateUpdateIngress(rule, namespace, ingress)
+		}
+	}
+
 	return nil
 }
 

--- a/client/services.go
+++ b/client/services.go
@@ -193,13 +193,6 @@ func ExternalNameServicesAreEqual(a, b *v1.Service) bool {
 		AnnotationsAreEqual(a.Annotations, b.Annotations))
 }
 
-func AnnotationsAreEqual(a, b map[string]string) bool {
-	aCopy := CopyAnnotations(a)
-	bCopy := CopyAnnotations(b)
-
-	return reflect.DeepEqual(aCopy, bCopy)
-}
-
 func PrepareExternalNameService(rule *typesv1.ExternalSyncRule, namespace *v1.Namespace, service *v1.Service) *v1.Service {
 	annotations := CopyAnnotations(service.Annotations)
 	annotations[constants.ManagedByAnnotationKey] = constants.ManagedByAnnotationValue
@@ -218,19 +211,6 @@ func PrepareExternalNameService(rule *typesv1.ExternalSyncRule, namespace *v1.Na
 			Ports:        service.Spec.Ports,
 		},
 	}
-}
-
-func CopyAnnotations(m map[string]string) map[string]string {
-	copy := make(map[string]string)
-
-	for key, value := range m {
-		if key == constants.ManagedByAnnotationKey || key == constants.LastAppliedConfigurationAnnotationKey {
-			continue
-		}
-		copy[key] = value
-	}
-
-	return copy
 }
 
 func IsServiceManagedBy(service *v1.Service) bool {

--- a/client/services.go
+++ b/client/services.go
@@ -199,10 +199,11 @@ func PrepareExternalNameService(rule *typesv1.ExternalSyncRule, namespace *v1.Na
 	return &v1.Service{
 		TypeMeta: service.TypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        service.Name,
-			Namespace:   namespace.Name,
-			Labels:      service.Labels,
-			Annotations: annotations,
+			Name:            service.Name,
+			Namespace:       namespace.Name,
+			Labels:          service.Labels,
+			Annotations:     annotations,
+			OwnerReferences: []metav1.OwnerReference{OwnerReference(rule)},
 		},
 		Spec: v1.ServiceSpec{
 			Type:         v1.ServiceTypeExternalName,

--- a/client/services.go
+++ b/client/services.go
@@ -72,25 +72,6 @@ func (client *Client) SyncAddedModifiedService(service *v1.Service) error {
 	return nil
 }
 
-func (client *Client) DeletedServiceHandler(service *v1.Service) error {
-	serviceLogger(service).Infof("deleted")
-
-	rules, err := client.ListExternalSyncRules()
-	if err != nil {
-		return err
-	}
-
-	for _, rule := range rules.Items {
-		if rule.ShouldSyncService(service) {
-			for _, namespace := range rule.Namespaces(client.Context, client.DefaultClientset) {
-				client.SyncDeletedService(&namespace, service)
-			}
-		}
-	}
-
-	return nil
-}
-
 func (client *Client) CreateUpdateExternalNameService(rule *typesv1.ExternalSyncRule, namespace *v1.Namespace, service *v1.Service) error {
 	logger := serviceLogger(service, namespace)
 
@@ -111,6 +92,25 @@ func (client *Client) CreateUpdateExternalNameService(rule *typesv1.ExternalSync
 	}
 
 	return client.CreateExternalNameService(rule, namespace, service)
+}
+
+func (client *Client) DeletedServiceHandler(service *v1.Service) error {
+	serviceLogger(service).Infof("deleted")
+
+	rules, err := client.ListExternalSyncRules()
+	if err != nil {
+		return err
+	}
+
+	for _, rule := range rules.Items {
+		if rule.ShouldSyncService(service) {
+			for _, namespace := range rule.Namespaces(client.Context, client.DefaultClientset) {
+				client.SyncDeletedService(&namespace, service)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (client *Client) SyncDeletedService(namespace *v1.Namespace, service *v1.Service) error {

--- a/client/services.go
+++ b/client/services.go
@@ -14,7 +14,7 @@ import (
 func (client *Client) ServiceEventHandler(event watch.Event) error {
 	service, ok := event.Object.(*v1.Service)
 	if !ok {
-		log.Error("failed to cast Secret")
+		log.Error("failed to cast Service")
 		return nil
 	}
 

--- a/client/services.go
+++ b/client/services.go
@@ -194,8 +194,7 @@ func ExternalNameServicesAreEqual(a, b *v1.Service) bool {
 }
 
 func PrepareExternalNameService(rule *typesv1.ExternalSyncRule, namespace *v1.Namespace, service *v1.Service) *v1.Service {
-	annotations := CopyAnnotations(service.Annotations)
-	annotations[constants.ManagedByAnnotationKey] = constants.ManagedByAnnotationValue
+	annotations := Manage(CopyAnnotations(service.Annotations))
 
 	return &v1.Service{
 		TypeMeta: service.TypeMeta,

--- a/client/watchers.go
+++ b/client/watchers.go
@@ -19,6 +19,10 @@ func (client *Client) InitializeWatchers() (err error) {
 		return err
 	}
 
+	if err := client.StartIngressWatcher(); err != nil {
+		return err
+	}
+
 	return
 }
 
@@ -34,5 +38,10 @@ func (client *Client) StartNamespaceWatcher() (err error) {
 
 func (client *Client) StartServiceWatcher() (err error) {
 	client.ServiceWatcher, err = client.DefaultClientset.CoreV1().Services(v1.NamespaceAll).Watch(client.Context, metav1.ListOptions{})
+	return
+}
+
+func (client *Client) StartIngressWatcher() (err error) {
+	client.IngressWatcher, err = client.DefaultClientset.NetworkingV1().Ingresses(v1.NamespaceAll).Watch(client.Context, metav1.ListOptions{})
 	return
 }

--- a/deploy/helm/kube-external-sync/templates/clusterrole.yaml
+++ b/deploy/helm/kube-external-sync/templates/clusterrole.yaml
@@ -8,6 +8,7 @@ rules:
       - ''
     resources:
       - services
+      - ingresses
     verbs:
       - get
       - list

--- a/deploy/helm/kube-external-sync/templates/crds/externalsyncrule.yaml
+++ b/deploy/helm/kube-external-sync/templates/crds/externalsyncrule.yaml
@@ -54,6 +54,8 @@ spec:
                         # - Ingress Route UDP
                     topLevelDomain:
                       type: string
+                    secretName: 
+                      type: string
                   required:
                     - name
                 rules:

--- a/deploy/helm/kube-external-sync/templates/crds/externalsyncrule.yaml
+++ b/deploy/helm/kube-external-sync/templates/crds/externalsyncrule.yaml
@@ -58,6 +58,7 @@ spec:
                       type: string
                   required:
                     - name
+                    - topLevelDomain
                 rules:
                   type: object
                   properties:

--- a/deploy/kubectl/external-rule.yaml
+++ b/deploy/kubectl/external-rule.yaml
@@ -6,6 +6,9 @@ spec:
   namespace: default
   service:
     name: nginx-external
+  ingress:
+    name: nginx-external
+    topLevelDomain: '*.feature.lehechka.com'
   rules:
     namespaces:
       includeAnnotation:

--- a/deploy/kubectl/ingress.yaml
+++ b/deploy/kubectl/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-external
+  namespace: default
+spec:
+  tls:
+    - hosts:
+        - external.lehechka.com
+  rules:
+    - host: external.lehechka.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: nginx-external
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=


### PR DESCRIPTION
This PR adds the synchronization of rule-defined Ingresses. The code will sync for ExternalSyncRule, Namespace, and Ingress events.

For the actual creation of Ingresses, the TLS and host section of rules will be populated by the required `topLevelDomain` attribute in the Ingress spec. The general logic is that given a TLD, it will strip the first subdomain and replace it with the current namespace (ex. `*.example.com` in the feature namespace will produce `feature.example.com`). All paths/ports/pathTypes will be copied directly.