### PR TITLE
Sync Ingresses

### DIFF
--- a/client/replicate/common/constants.go
+++ b/client/replicate/common/constants.go
@@ -44,9 +44,3 @@ const (
 	DefaultExternalNameSuffix     = "svc.cluster.local"
 	TraefikMeshExternalNameSuffix = "traefik.mesh"
 )
-
-// ExternalNameOptions array of available ExternalName suffixes
-var ExternalNameOptions = map[string]struct{}{
-	DefaultExternalNameSuffix:     {},
-	TraefikMeshExternalNameSuffix: {},
-}

--- a/client/replicate/common/generic-replicator.go
+++ b/client/replicate/common/generic-replicator.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// ReplicatorConfig represents configuration for individual resource controllers
 type ReplicatorConfig struct {
 	Kind         string
 	Client       kubernetes.Interface
@@ -28,12 +29,14 @@ type ReplicatorConfig struct {
 	ObjType      runtime.Object
 }
 
+// UpdateFuncs stores the resource updater functions
 type UpdateFuncs struct {
 	ReplicateDataFrom        func(source interface{}, target interface{}) error
 	ReplicateObjectTo        func(source interface{}, target *v1.Namespace) error
 	DeleteReplicatedResource func(target interface{}) error
 }
 
+// GenericReplicator represents the top-level Replicator
 type GenericReplicator struct {
 	ReplicatorConfig
 	Store      cache.Store
@@ -83,10 +86,12 @@ func NewGenericReplicator(ctx context.Context, config ReplicatorConfig) *Generic
 	return &repl
 }
 
+// Synced reports whether or not the controller has been synced
 func (r *GenericReplicator) Synced() bool {
 	return r.Controller.HasSynced()
 }
 
+// Run starts the controller
 func (r *GenericReplicator) Run() {
 	log.WithField("kind", r.Kind).Infof("running %s controller", r.Kind)
 	r.Controller.Run(wait.NeverStop)

--- a/client/replicate/common/generic-replicator.go
+++ b/client/replicate/common/generic-replicator.go
@@ -229,9 +229,6 @@ func (r *GenericReplicator) ResourceUpdated(old interface{}, new interface{}) {
 // replicateResourceToMatchingNamespaces replicates resources with ReplicateTo annotation
 func (r *GenericReplicator) replicateResourceToMatchingNamespaces(obj interface{}, patterns string, namespaceList []v1.Namespace) error {
 	cacheKey := MustGetKey(obj)
-	logger := log.WithField("kind", r.Kind).WithField("source", cacheKey).WithField("patterns", patterns)
-
-	logger.Infof("%s %s to be replicated", r.Kind, cacheKey)
 
 	replicateTo := r.getFilteredNamespaces(MustGetObject(obj).GetNamespace(), patterns, namespaceList)
 
@@ -256,8 +253,6 @@ func (r *GenericReplicator) replicateResourceToNamespaces(obj interface{}, targe
 			))
 		} else {
 			replicatedTo = append(replicatedTo, namespace)
-			logger := log.WithField("source", cacheKey)
-			logger.Infof("Replicated %s to: %v", cacheKey, namespace.Name)
 		}
 	}
 

--- a/client/replicate/ingress/ingresses.go
+++ b/client/replicate/ingress/ingresses.go
@@ -3,9 +3,11 @@ package ingress
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/alehechka/kube-external-sync/client/replicate/common"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -36,8 +38,9 @@ func NewReplicator(ctx context.Context, client kubernetes.Interface, resyncPerio
 		}),
 	}
 	repl.UpdateFuncs = common.UpdateFuncs{
-		ReplicateDataFrom: repl.ReplicateDataFrom,
-		ReplicateObjectTo: repl.ReplicateObjectTo,
+		ReplicateDataFrom:        repl.ReplicateDataFrom,
+		ReplicateObjectTo:        repl.ReplicateObjectTo,
+		DeleteReplicatedResource: repl.DeleteReplicatedResource,
 	}
 
 	return &repl
@@ -51,24 +54,122 @@ func (r *Replicator) ReplicateDataFrom(sourceObj interface{}, targetObj interfac
 	logger := log.
 		WithField("kind", r.Kind).
 		WithField("source", common.MustGetKey(source)).
-		WithField("tartget", common.MustGetKey(target))
+		WithField("target", common.MustGetKey(target))
 
-	logger.Infof("ReplicateDataFrom")
+	if !common.IsManagedBy(target) {
+		logger.Debugf("target is not managed and will not be synced")
+		return nil
+	}
 
-	return nil
+	targetVersion, ok := target.Annotations[common.ReplicatedFromVersionAnnotation]
+	sourceVersion := source.ResourceVersion
+
+	if ok && targetVersion == sourceVersion {
+		logger.Debugf("target is already up-to-date")
+		return nil
+	}
+
+	prepared := prepareIngress(target.Namespace, source)
+	service, err := r.Client.NetworkingV1().Ingresses(target.Namespace).Update(r.Context, prepared, metav1.UpdateOptions{})
+	if err != nil {
+		err = errors.Wrapf(err, "Failed updating target %s", common.MustGetKey(prepared))
+	} else if err = r.Store.Update(service); err != nil {
+		err = errors.Wrapf(err, "Failed to update cache for %s: %v", common.MustGetKey(prepared), err)
+	}
+	return err
 }
 
 // ReplicateObjectTo copies the whole object to target namespace
-func (r *Replicator) ReplicateObjectTo(sourceObj interface{}, target *v1.Namespace) error {
+func (r *Replicator) ReplicateObjectTo(sourceObj interface{}, targetNamespace *v1.Namespace) error {
 	source := sourceObj.(*networkingv1.Ingress)
-	targetLocation := fmt.Sprintf("%s/%s", target.Name, source.Name)
+	targetLocation := fmt.Sprintf("%s/%s", targetNamespace.Name, source.Name)
 
-	logger := log.
-		WithField("kind", r.Kind).
-		WithField("source", common.MustGetKey(source)).
-		WithField("target", targetLocation)
+	targetResource, exists, err := r.Store.GetByKey(targetLocation)
+	if err != nil {
+		return errors.Wrapf(err, "Could not get %s from cache!", targetLocation)
+	}
 
-	logger.Infof("ReplicateObjectTo")
+	if exists {
+		return r.ReplicateDataFrom(source, (targetResource).(*networkingv1.Ingress))
+	}
 
-	return nil
+	prepared := prepareIngress(targetNamespace.Name, source)
+	service, err := r.Client.NetworkingV1().Ingresses(targetNamespace.Name).Create(r.Context, prepared, metav1.CreateOptions{})
+	if err != nil {
+		err = errors.Wrapf(err, "Failed creating target %s", common.MustGetKey(prepared))
+	} else if err = r.Store.Update(service); err != nil {
+		err = errors.Wrapf(err, "Failed to update cache for %s: %v", common.MustGetKey(prepared), err)
+	}
+	return err
+}
+
+// DeleteReplicatedResource deletes a resource replicated by ReplicateTo annotation
+func (r *Replicator) DeleteReplicatedResource(targetResource interface{}) error {
+	ingress := targetResource.(*networkingv1.Ingress)
+	return r.Client.NetworkingV1().Ingresses(ingress.Namespace).Delete(r.Context, ingress.Name, metav1.DeleteOptions{})
+}
+
+func prepareIngress(namespace string, source *networkingv1.Ingress) *networkingv1.Ingress {
+	return &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            source.Name,
+			Namespace:       namespace,
+			Labels:          common.PrepareLabels(source.ObjectMeta),
+			Annotations:     common.PrepareAnnotations(source.ObjectMeta),
+			OwnerReferences: common.PrepareOwnerReferences(source.ObjectMeta),
+		},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: source.Spec.IngressClassName,
+			DefaultBackend:   source.Spec.DefaultBackend,
+			TLS:              prepareTLS(namespace, source),
+			Rules:            prepareRules(namespace, source),
+		},
+	}
+}
+
+func prepareTLS(namespace string, source *networkingv1.Ingress) (ingressTLS []networkingv1.IngressTLS) {
+	annotations := source.GetAnnotations()
+
+	if tld, ok := annotations[common.TopLevelDomain]; ok {
+		return []networkingv1.IngressTLS{{
+			SecretName: annotations[common.TLDSecretName],
+			Hosts:      []string{prepareTLD(namespace, tld)},
+		}}
+	}
+
+	for _, tls := range source.Spec.TLS {
+		entry := networkingv1.IngressTLS{SecretName: tls.SecretName}
+		for _, host := range tls.Hosts {
+			entry.Hosts = append(entry.Hosts, prepareTLD(namespace, host))
+		}
+		ingressTLS = append(ingressTLS, entry)
+	}
+
+	return
+}
+
+func prepareRules(namespace string, source *networkingv1.Ingress) (rules []networkingv1.IngressRule) {
+	tld, ok := source.GetAnnotations()[common.TopLevelDomain]
+	prepared := prepareTLD(namespace, tld)
+
+	for _, rule := range source.Spec.Rules {
+		host := prepared
+		if !ok {
+			host = prepareTLD(namespace, rule.Host)
+		}
+
+		rules = append(rules, networkingv1.IngressRule{
+			Host:             host,
+			IngressRuleValue: rule.IngressRuleValue,
+		})
+	}
+
+	return
+}
+
+func prepareTLD(namespace, tld string) string {
+	subdomains := strings.Split(tld, ".")
+	subdomains[0] = namespace
+
+	return strings.Join(subdomains, ".")
 }

--- a/client/replicate/ingress/ingresses.go
+++ b/client/replicate/ingress/ingresses.go
@@ -106,6 +106,13 @@ func (r *Replicator) ReplicateObjectTo(sourceObj interface{}, targetNamespace *v
 // DeleteReplicatedResource deletes a resource replicated by ReplicateTo annotation
 func (r *Replicator) DeleteReplicatedResource(targetResource interface{}) error {
 	ingress := targetResource.(*networkingv1.Ingress)
+
+	if !common.IsManagedBy(ingress) {
+		log.WithField("kind", r.Kind).WithField("target", common.MustGetKey(ingress)).
+			Debugf("target is not managed and will not be deleted")
+		return nil
+	}
+
 	return r.Client.NetworkingV1().Ingresses(ingress.Namespace).Delete(r.Context, ingress.Name, metav1.DeleteOptions{})
 }
 

--- a/client/replicate/service/services.go
+++ b/client/replicate/service/services.go
@@ -129,10 +129,8 @@ func prepareExternalName(namespace string, source *v1.Service) string {
 }
 
 func getExternalNameSuffix(source *v1.Service) string {
-	if suffix, ok := source.Annotations[common.ExternalNameSuffix]; ok {
-		if _, ok := common.ExternalNameOptions[suffix]; ok {
-			return suffix
-		}
+	if suffix, ok := source.Annotations[common.ExternalNameSuffix]; ok && len(suffix) > 0 {
+		return suffix
 	}
 
 	return common.DefaultExternalNameSuffix

--- a/client/replicate/service/services.go
+++ b/client/replicate/service/services.go
@@ -80,15 +80,15 @@ func (r *Replicator) ReplicateDataFrom(sourceObj interface{}, targetObj interfac
 // ReplicateObjectTo copies the whole object to target namespace
 func (r *Replicator) ReplicateObjectTo(sourceObj interface{}, targetNamespace *v1.Namespace) error {
 	source := sourceObj.(*v1.Service)
+	sourceKey := common.MustGetKey(source)
 	targetLocation := fmt.Sprintf("%s/%s", targetNamespace.Name, source.Name)
 
-	targetResource, exists, err := r.Store.GetByKey(targetLocation)
-	if err != nil {
-		return errors.Wrapf(err, "Could not get %s from cache!", targetLocation)
-	}
+	logger := log.WithField("source", sourceKey).WithField("target", targetLocation).WithField("kind", r.Kind)
+	logger.Infof("Replicating %s to %s", sourceKey, targetNamespace.Name)
 
-	if exists {
-		return r.ReplicateDataFrom(source, (targetResource).(*v1.Service))
+	targetResource, err := r.Client.CoreV1().Services(targetNamespace.Name).Get(r.Context, source.Name, metav1.GetOptions{})
+	if err == nil && targetResource != nil {
+		return r.ReplicateDataFrom(source, targetResource)
 	}
 
 	prepared := prepareExternalNameService(targetNamespace.Name, source)

--- a/client/replicate/service/services.go
+++ b/client/replicate/service/services.go
@@ -104,6 +104,13 @@ func (r *Replicator) ReplicateObjectTo(sourceObj interface{}, targetNamespace *v
 // DeleteReplicatedResource deletes a resource replicated by ReplicateTo annotation
 func (r *Replicator) DeleteReplicatedResource(targetResource interface{}) error {
 	service := targetResource.(*v1.Service)
+
+	if !common.IsManagedBy(service) {
+		log.WithField("kind", r.Kind).WithField("target", common.MustGetKey(service)).
+			Debugf("target is not managed and will not be deleted")
+		return nil
+	}
+
 	return r.Client.CoreV1().Services(service.Namespace).Delete(r.Context, service.Name, metav1.DeleteOptions{})
 }
 


### PR DESCRIPTION
The core of this PR is to add the functionality for syncing Ingresses to selected namespaces.

However, it was found that when the base resource has its annotations changed to where some previously synced resources no longer apply, they are not cleaned up. This PR adds a new ResourceUpdated function and deletion functions to check the old vs new resource to determine which replicants are no longer applicable and deletes them.