### PR TITLE
Resolve faulty hostname matches of replicated IngressRoutes

### DIFF
--- a/client/replicate/traefik/ingressroute/ingressroutes.go
+++ b/client/replicate/traefik/ingressroute/ingressroutes.go
@@ -138,6 +138,9 @@ func prepareIngressRoute(namespace string, source *v1alpha1.IngressRoute) *v1alp
 }
 
 func prepareRoutes(namespace string, source *v1alpha1.IngressRoute) (routes []v1alpha1.Route) {
+	annotations := source.GetAnnotations()
+	hostname := annotations[common.TopLevelDomain]
+
 	for _, route := range source.Spec.Routes {
 		newRoute := v1alpha1.Route{
 			Kind:        route.Kind,
@@ -146,7 +149,7 @@ func prepareRoutes(namespace string, source *v1alpha1.IngressRoute) (routes []v1
 			Priority:    route.Priority,
 		}
 
-		newRoute.Match = traefik.PrepareRouteMatch(namespace, route.Match)
+		newRoute.Match = traefik.PrepareRouteMatch(namespace, route.Match, hostname)
 
 		routes = append(routes, newRoute)
 	}

--- a/client/replicate/traefik/tls.go
+++ b/client/replicate/traefik/tls.go
@@ -7,7 +7,7 @@ import (
 )
 
 // PrepareRouteMatch replaces all domains with the namespaced version
-func PrepareRouteMatch(namespace, match string) string {
+func PrepareRouteMatch(namespace, match string, hostname string) string {
 	if !strings.Contains(match, "Host") {
 		return match
 	}
@@ -17,7 +17,7 @@ func PrepareRouteMatch(namespace, match string) string {
 	isHost := false
 	for index, part := range parenParts {
 		if isHost {
-			parenParts[index] = prepareDomainStrings(namespace, part)
+			parenParts[index] = prepareDomainStrings(namespace, part, hostname)
 			isHost = false
 			continue
 		}
@@ -29,13 +29,18 @@ func PrepareRouteMatch(namespace, match string) string {
 	return strings.Join(parenParts, "")
 }
 
-func prepareDomainStrings(namespace, domainString string) string {
+func prepareDomainStrings(namespace, domainString, hostname string) string {
 	parts := strings.Split(domainString, "`")
 
 	isHost := false
 	for index, part := range parts {
 		if isHost {
-			parts[index] = common.PrepareTLD(namespace, part)
+			if len(hostname) > 0 {
+				parts[index] = common.PrepareTLD(namespace, hostname)
+			} else {
+				parts[index] = common.PrepareTLD(namespace, part)
+			}
+
 			isHost = false
 			continue
 		}

--- a/client/replicate/traefik/tls_test.go
+++ b/client/replicate/traefik/tls_test.go
@@ -8,50 +8,62 @@ import (
 
 func Test_PrepareRouteMatch_NoHost(t *testing.T) {
 	match := "PathPrefix(`/`)"
-	newMatch := PrepareRouteMatch("default", match)
+	newMatch := PrepareRouteMatch("default", match, "")
 	assert.Equal(t, match, newMatch)
 }
 
 func Test_PrepareRouteMatch_OneHost(t *testing.T) {
 	match := "Host(`subdomain.example.com`)"
-	newMatch := PrepareRouteMatch("default", match)
+	newMatch := PrepareRouteMatch("default", match, "")
 	assert.Equal(t, "Host(`default.example.com`)", newMatch)
+}
+
+func Test_PrepareRouteMatch_OneHost_WithFallback(t *testing.T) {
+	match := "Host(`subdomain.example.com`)"
+	newMatch := PrepareRouteMatch("default", match, "*.other.com")
+	assert.Equal(t, "Host(`default.other.com`)", newMatch)
 }
 
 func Test_PrepareRouteMatch_TwoHosts(t *testing.T) {
 	match := "Host(`subdomain.example.com`) || Host(`subdomain.placeholder.com`)"
-	newMatch := PrepareRouteMatch("default", match)
+	newMatch := PrepareRouteMatch("default", match, "")
 	assert.Equal(t, "Host(`default.example.com`) || Host(`default.placeholder.com`)", newMatch)
 }
 
 func Test_PrepareRouteMatch_HostPathPrefix(t *testing.T) {
 	match := "Host(`subdomain.example.com`) && PathPrefix(`/`)"
-	newMatch := PrepareRouteMatch("default", match)
+	newMatch := PrepareRouteMatch("default", match, "")
 	assert.Equal(t, "Host(`default.example.com`) && PathPrefix(`/`)", newMatch)
 }
 
 func Test_PrepareRouteMatch_HostPathPrefixHost(t *testing.T) {
 	match := "(Host(`subdomain.example.com`) && PathPrefix(`/`)) || Host(`subdomain.placeholder.com`)"
-	newMatch := PrepareRouteMatch("default", match)
+	newMatch := PrepareRouteMatch("default", match, "")
 	assert.Equal(t, "(Host(`default.example.com`) && PathPrefix(`/`)) || Host(`default.placeholder.com`)", newMatch)
 }
 
 func Test_PrepareRouteMatch_MultiHosts(t *testing.T) {
 	match := "Host(`subdomain.example.com`, `other.example.com`)"
-	newMatch := PrepareRouteMatch("default", match)
+	newMatch := PrepareRouteMatch("default", match, "")
 	assert.Equal(t, "Host(`default.example.com`, `default.example.com`)", newMatch)
 }
 
 func Test_PrepareRouteMatch_Complex(t *testing.T) {
 	match := "(Host(`subdomain.example.com`, `other.example.com`) && PathPrefix(`/`)) || Host(`subdomain.placeholder.com`, `other.placeholder.com`)"
-	newMatch := PrepareRouteMatch("default", match)
+	newMatch := PrepareRouteMatch("default", match, "")
 	assert.Equal(t, "(Host(`default.example.com`, `default.example.com`) && PathPrefix(`/`)) || Host(`default.placeholder.com`, `default.placeholder.com`)", newMatch)
 }
 
 func Test_prepareDomainStrings(t *testing.T) {
-	assert.Equal(t, "(`default.example.com`", prepareDomainStrings("default", "(`subdomain.example.com`"))
-	assert.Equal(t, "`default.example.com`", prepareDomainStrings("default", "`subdomain.example.com`"))
-	assert.Equal(t, "`default.example.com`, `default.placeholder.com`", prepareDomainStrings("default", "`subdomain.example.com`, `subdomain.placeholder.com`"))
+	assert.Equal(t, "(`default.example.com`", prepareDomainStrings("default", "(`subdomain.example.com`", ""))
+	assert.Equal(t, "`default.example.com`", prepareDomainStrings("default", "`subdomain.example.com`", ""))
+	assert.Equal(t, "`default.example.com`, `default.placeholder.com`", prepareDomainStrings("default", "`subdomain.example.com`, `subdomain.placeholder.com`", ""))
+}
+
+func Test_prepareDomainStrings_WithFallback(t *testing.T) {
+	assert.Equal(t, "(`default.other.com`", prepareDomainStrings("default", "(`subdomain.example.com`", "*.other.com"))
+	assert.Equal(t, "`default.other.com`", prepareDomainStrings("default", "`subdomain.example.com`", "*.other.com"))
+	assert.Equal(t, "`default.other.com`, `default.other.com`", prepareDomainStrings("default", "`subdomain.example.com`, `subdomain.placeholder.com`", "*.other.com"))
 }
 
 func Test_uncutSplit(t *testing.T) {


### PR DESCRIPTION
# Overview
Through usage of IngressRoute replication, it was found that the `top-level-domain` annotation (which should likely be renamed at some point), was not being supplied to the rules preparation functions. Meaning that the Host rules in the match variable was not able to use a custom hostname. In my use case which puts feature branch namespaces at `*.feature.example.com`, it meant that it would replicate the match rules as `<feature-name>.com`. 

Passing the hostname as a fallback (or forward?) for the replacement proves testing results. 