### PR TITLE
Resolve newline suffix edge case

### DIFF
--- a/client/replicate/traefik/tls.go
+++ b/client/replicate/traefik/tls.go
@@ -57,6 +57,9 @@ func uncutSplit(str string, delimiter func(rune) bool) (strs []string) {
 		return make([]string, 0)
 	}
 
+	// Helm chart's can produce edge case where string ends with newline and messes with the rest of this algorithm. Simply trimming it here fixes it.
+	str = strings.TrimSuffix(str, "\n")
+
 	var prev int
 	for index, char := range str {
 		if delimiter(char) {

--- a/client/replicate/traefik/tls_test.go
+++ b/client/replicate/traefik/tls_test.go
@@ -54,6 +54,12 @@ func Test_PrepareRouteMatch_Complex(t *testing.T) {
 	assert.Equal(t, "(Host(`default.example.com`, `default.example.com`) && PathPrefix(`/`)) || Host(`default.placeholder.com`, `default.placeholder.com`)", newMatch)
 }
 
+func Test_PrepareRouteMatch_NewLineSuffix(t *testing.T) {
+	match := "Host(`example.com`) && Path(`/path1`,`/path2`,`/path3`)\n"
+	newMatch := PrepareRouteMatch("default", match, "*.example.com")
+	assert.Equal(t, "Host(`default.example.com`) && Path(`/path1`,`/path2`,`/path3`)", newMatch)
+}
+
 func Test_prepareDomainStrings(t *testing.T) {
 	assert.Equal(t, "(`default.example.com`", prepareDomainStrings("default", "(`subdomain.example.com`", ""))
 	assert.Equal(t, "`default.example.com`", prepareDomainStrings("default", "`subdomain.example.com`", ""))


### PR DESCRIPTION
Found edge case with Helm chart templating where a newline character is appended to the end of the `match` string and breaks the string splitting algorithm. This solution isn't the prettiest, but gets the job done.