### PR TITLE
Resolve issues with Helm chart deployment

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
 
       - name: Install dependencies
         run: go mod download
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
 
       - name: Install controller-gen
         run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
@@ -66,3 +66,23 @@ jobs:
           else 
             echo "No Changes" 
           fi
+
+  validate-helm-charts:
+    name: Validate Helm Charts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install helm
+        uses: Azure/setup-helm@v3
+
+      - name: Lint Helm Chart
+        run: helm lint deploy/helm/kube-external-sync
+
+      - name: Package Helm Chart
+        run: helm package deploy/helm/kube-external-sync
+
+      - name: Template Helm Chart
+        run: helm template helm-charts deploy/helm/kube-external-sync

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: 1.19
 
       - name: Install dependencies
         run: go mod download

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -40,33 +40,6 @@ jobs:
       - name: Build Docker image
         run: docker build -t kube-external-sync .
 
-  pr-generate:
-    name: Pull Request Generate Verification
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20
-
-      - name: Install controller-gen
-        run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
-
-      - name: Generate DeepCopy file
-        run: make generate
-
-      - name: Check diffs
-        run: |
-          if [[ `git status --porcelain` ]]; then 
-            echo "Changes" 
-            exit 1
-          else 
-            echo "No Changes" 
-          fi
-
   validate-helm-charts:
     name: Validate Helm Charts
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,9 +31,9 @@ jobs:
         id: image
         run: |
           if [ "${{ github.ref_type }}" = "tag" ]; then
-            echo "::set-output name=tag::${{ github.ref_name }}"
+            echo "tag=${{ github.ref_name }}"  >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=tag::latest"
+            echo "name=tag=latest"  >> $GITHUB_OUTPUT
           fi
 
       - uses: docker/build-push-action@v3
@@ -58,15 +58,13 @@ jobs:
 
       - name: Setup Helm
         uses: azure/setup-helm@v3
-        with:
-          version: 'v3.9.4'
 
       - name: Get Chart version
         id: chart
         run: |
           VERSION=${{ github.ref_name }}
 
-          echo "::set-output name=version::${VERSION##*v}"
+          echo "version=${VERSION##*v}"  >> $GITHUB_OUTPUT
 
       - name: Update versions
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # BUILD SERVER
 
-FROM golang:1.19-alpine as go-builder
+FROM golang:1.20-alpine as go-builder
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,3 @@ start:
 		--enable-traefik \
 		--pod-namespace kube-external-sync \
 		--default-ingress-hostname "*.example.com"
-
-generate:
-	controller-gen object paths=./...

--- a/deploy/helm/kube-external-sync/templates/deployment.yaml
+++ b/deploy/helm/kube-external-sync/templates/deployment.yaml
@@ -28,9 +28,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: LOG_LEVEL
-              value: {{ .Values.deployment.env.LOG_LEVEL }}
+              value: {{ .Values.deployment.config.LOG_LEVEL }}
             - name: LOG_FORMAT
-              value: {{ .Values.deployment.env.LOG_FORMAT }}
+              value: {{ .Values.deployment.config.LOG_FORMAT }}
             - name: LIVENESS_PORT
               value: {{ .Values.deployment.port | quote }}
             - name: RESYNC_PERIOD


### PR DESCRIPTION
# Overview
PR #21 did not validate the Helm chart and thus failed to [release](https://github.com/alehechka/kube-external-sync/actions/runs/4760533231/jobs/8460949622).
- Fixed problems with Helm chart
- Added Helm validation to PR workflows
- Migrated deprecated `set-output` usage in GHA workflows
- Updated GHA dependencies
- Updated base Dockerfile image